### PR TITLE
Remove unused variable

### DIFF
--- a/filter_plugins/config_block.py
+++ b/filter_plugins/config_block.py
@@ -44,7 +44,6 @@ def parse_config(config, indent=1):
 
     ancestors = list()
     data = collections.OrderedDict()
-    banner = False
 
     for line in config:
         text = str(line).strip()


### PR DESCRIPTION
When running the tests - the following error occurs:

filter_plugins/config_block.py:47:5: F841 local variable 'banner' is assigned to but never used
make: *** [flake8] Error 1